### PR TITLE
Update app_bloc.dart

### DIFF
--- a/lib/screen_app/app_bloc.dart
+++ b/lib/screen_app/app_bloc.dart
@@ -26,7 +26,7 @@ class AppBloc extends Bloc<AppEvent, AppState> {
     });
   }
 
-  int _idChannel = 1;
+  int _idChannel = ID_CHANNEL_MEDIUM;
   int _lastPositionChecked = 0;
 
   @override
@@ -51,11 +51,11 @@ class AppBloc extends Bloc<AppEvent, AppState> {
 
     if (_bufferCapacity > PLAYER_BUFFER_HIGH_CAPACITY) {
       switch (_idChannel) {
-        case 0:
-          _switchStream(STREAM_MED_URL,1);
+        case ID_CHANNEL_LOW:
+          _switchStream(STREAM_MED_URL,ID_CHANNEL_MEDIUM);
           break;
-        case 1:
-          _switchStream(STREAM_HIGH_URL,2);
+        case ID_CHANNEL_MEDIUM:
+          _switchStream(STREAM_HIGH_URL,ID_CHANNEL_HI);
           break;
       }
       _lastPositionChecked = _player.position.inSeconds;
@@ -64,11 +64,11 @@ class AppBloc extends Bloc<AppEvent, AppState> {
 
     if (_bufferCapacity < PLAYER_BUFFER_LOW_CAPACITY) {
       switch (_idChannel) {
-        case 2:
-          _switchStream(STREAM_MED_URL,1);
+        case ID_CHANNEL_HI:
+          _switchStream(STREAM_MED_URL,ID_CHANNEL_MEDIUM);
           break;
-        case 1:
-          _switchStream(STREAM_LOW_URL,0);
+        case ID_CHANNEL_MEDIUM:
+          _switchStream(STREAM_LOW_URL,ID_CHANNEL_LOW);
           break;
       }
       _lastPositionChecked = _player.position.inSeconds;
@@ -87,15 +87,15 @@ class AppBloc extends Bloc<AppEvent, AppState> {
     }
     try {
       switch(_idChannel){
-        case 0:
+        case ID_CHANNEL_LOW:
           final _newSource = AudioSource.uri(Uri.parse(STREAM_LOW_URL));
           await _player.setAudioSource(_newSource);
           break;
-        case 1:
+        case ID_CHANNEL_MEDIUM:
           final _newSource = AudioSource.uri(Uri.parse(STREAM_MED_URL));
           await _player.setAudioSource(_newSource);
           break;
-        case 2:
+        case ID_CHANNEL_HI:
           final _newSource = AudioSource.uri(Uri.parse(STREAM_HIGH_URL));
           await _player.setAudioSource(_newSource);
           break;

--- a/lib/utils/constants/constants.dart
+++ b/lib/utils/constants/constants.dart
@@ -7,6 +7,10 @@ const LOGO_IMAGE = "assets/images/union_radio_logo.png";
 const STREAM_LOW_URL = "http://78.155.222.238:8010/souz_radio_64.mp3";
 const STREAM_MED_URL = "http://78.155.222.238:8010/souz_radio_128.mp3";
 const STREAM_HIGH_URL = "http://78.155.222.238:8010/souz_radio_192.mp3";
+//Streams IDs
+const ID_CHANNEL_LOW = 0;
+const ID_CHANNEL_MEDIUM = 1;
+const ID_CHANNEL_HI = 2;
 // Периодичность проверки буффера плеера на заполненность. В сек.
 const PLAYER_BUFFER_CHECK_DURATION = 3;
 const PLAYER_BUFFER_UNCHECKABLE_DURATION = 5;


### PR DESCRIPTION
Сменил проверку текущего канала на проверку по id, то есть убрал сравнение строк, добавил ограничение на проверку заполненности буфера в 5 секунд с момента последней смены каналов, чтобы не возникало ситуации что буфер проверялся почти сразу после смены канала. Также насколько я посмотрел возможно имеет смысл понизить нижнюю границу буфера до 1 секунды во избежание ситуаций когда скорости интернета хватает чтобы без проблем грузить один поток, но поток качества выше не мог грузить буфер более чем на 2 секунды вперёд, создавая постоянную смену каналов.